### PR TITLE
Refactoring and renaming add ons to apps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ Include any relevant logs
 
 **Environment (please complete the following information):**
 
-- Add-on version: [e.g. 1.0.2]
+- App version: [e.g. 1.0.2]
 - Supervisor version: [e.g.supervisor-2021.03.6]
 - Operating system [e.g. Home Assistant OS 5.12]
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,7 +44,7 @@
     {
       "matchDatasources": ["docker"],
       "commitMessagePrefix": "⬆️",
-      "commitMessageTopic": "Addon Base Image"
+      "commitMessageTopic": "App Base Image"
     },
     {
       "matchDatasources": ["repology"],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ permissions:
   packages: read
   security-events: write
 
-
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,13 +3,19 @@ name: CI
 
 # yamllint disable-line rule:truthy
 on:
-  push:
   pull_request:
     types:
       - opened
       - reopened
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+
 jobs:
   workflows:
-    uses: casse-boubou/ha-addon-workflows/.github/workflows/addon-ci.yaml@main
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,18 +3,30 @@ name: Deploy
 
 # yamllint disable-line rule:truthy
 on:
+  push:
+    branches:
+      - main
   release:
     types:
       - published
-  workflow_run:
-    workflows: ["CI"]
-    branches: [main]
-    types:
-      - completed
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  workflows:
-    uses: casse-boubou/ha-addon-workflows/.github/workflows/addon-deploy.yaml@main
+  ci:
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main
+
+  deploy:
+    needs: ci
+    permissions:
+      contents: read
+      packages: write
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-deploy.yaml@main
     secrets:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,11 +1,14 @@
 ---
-name: Sync labels
+name: Sync Labels
 
 # yamllint disable-line rule:truthy
 on:
   schedule:
     - cron: "34 5 * * *"
   workflow_dispatch:
+
+permissions:
+  issues: write
 
 jobs:
   workflows:

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/lock.yaml@main

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -6,8 +6,11 @@ on:
   pull_request:
     types:
       - opened
+      - labeled
+      - unlabeled
       - synchronize
-  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   workflows:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/release-drafter.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/stale.yaml@main

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2022-2025 Frosh
+Copyright (c) 2022-2026 Frosh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ la [page des contributeurs][contributors].
 
 MIT License
 
-Copyright (c) 2022-2025 [Frosh][Frosh]
+Copyright (c) 2022-2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: Sharry dependency-less
+# Home Assistant App: Sharry dependency-less
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE)
@@ -8,16 +8,16 @@
 [Sharry][sharry] permet de partager des fichiers avec d'autres de manière
 simple.
 
-Il s'agit ici d'une version modifier [de cet add-on][addon-sharry] dans laquelle
-l'add-on Maria db est integrer.
+Il s'agit ici d'une version modifier [de cet app][app-sharry] dans laquelle
+l'app Maria db est integrer.
 
-[![Open your Home Assistant instance and show the add add-on repository dialog
+[![Open your Home Assistant instance and show the add app repository dialog
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
+[![Open your Home Assistant instance and show the dashboard of a Supervisor app.][add-app-shield]][add-app]
 
 ## About
 
-Cet add-on permet un partage de fichiers rapidement et facilement.
+Cet app permet un partage de fichiers rapidement et facilement.
 Vous glisser et déposez des fichiers et obtenez un lien que vous pouvez partager
 avec n'importe qui.
 Vous pouvez également créer et partager des liens avec d'autres personnes
@@ -34,7 +34,7 @@ vidéos.
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement
 autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][hacf] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.
@@ -71,11 +71,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-[add-addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_sharry-dependency-less
-[add-addon-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
+[add-app]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_sharry-dependency-less
+[add-app-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A//github.com/casse-boubou/hassio-addons
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
-[addon-sharry]: https://github.com/casse-boubou/addon-sharry
+[app-sharry]: https://github.com/casse-boubou/addon-sharry
 [releases]: https://github.com/casse-boubou/addon-sharry-dependency-less/releases
 [releases-shield]: https://img.shields.io/github/v/release/casse-boubou/addon-sharry-dependency-less
 [license-shield]: https://img.shields.io/github/license/casse-boubou/addon-sharry-dependency-less

--- a/sharry/.README.j2
+++ b/sharry/.README.j2
@@ -38,7 +38,7 @@ Pour une liste complète des auteurs et contributeurs merci de consulter la [pag
 
 MIT License
 
-Copyright (c) 2022-2025 [Frosh][Frosh]
+Copyright (c) 2022-2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sharry/.README.j2
+++ b/sharry/.README.j2
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: Sharry dependency-less
+# Home Assistant App: Sharry dependency-less
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]][license]
@@ -10,9 +10,9 @@
 
 Ce projet est un fork du projet original de [Mike Degatano][mike-sharry] auquel j'ai rajouter la possibilitée de stocker les fichier directement dans un dossier local ainsi que de copier la base de donnée de Mariadb à un stockage local ou inversement.
 
-Il s'agit ici d'une version modifier [de cet add-on][addon-sharry] dans laquelle l'add-on Maria db est integrer.
+Il s'agit ici d'une version modifier [de cet app][app-sharry] dans laquelle l'app Maria db est integrer.
 
-Cet add-on permet un partage de fichiers rapidement et facilement.
+Cet app permet un partage de fichiers rapidement et facilement.
 Vous glisser et déposez des fichiers et obtenez un lien que vous pouvez partager avec n'importe qui.
 Vous pouvez également créer et partager des liens avec d'autres personnes qu'elles utiliseront pour partager des fichiers avec vous.
 Toute personne disposant d'un lien de partage peut y accéder, mais seulement les utilisateurs authentifiée peuvent créer de nouveaux liens de partage.
@@ -22,7 +22,7 @@ Il a également quelques fonctionnalités intéressantes comme les téléchargem
 ## Support
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][HACF] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.
@@ -95,4 +95,4 @@ SOFTWARE.
 
 [releases]: https://github.com/casse-boubou/addon-sharry-dependency-less/releases
 [releases-shield]: https://img.shields.io/github/v/release/casse-boubou/addon-sharry-dependency-less
-[addon-sharry]:https://github.com/casse-boubou/addon-sharry
+[app-sharry]:https://github.com/casse-boubou/addon-sharry

--- a/sharry/DOCS.md
+++ b/sharry/DOCS.md
@@ -1,15 +1,15 @@
-# Home Assistant Add-on: Sharry dependency-less
+# Home Assistant App: Sharry dependency-less
 
 ## Install
 
-D'habord ajoutez le repertoire à l'add-on store de HomeAssistant (`https://github.com/casse-boubou/hassio-addons`):
+D'habord ajoutez le repertoire à l'app store de HomeAssistant (`https://github.com/casse-boubou/hassio-addons`):
 
-[![Open your Home Assistant instance and show the add add-on repository dialog
+[![Open your Home Assistant instance and show the add app repository dialog
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 
 Ensuite recherchez Sharry-dependency-less dans le store et cliquez sur installer:
 
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
+[![Open your Home Assistant instance and show the dashboard of a Supervisor app.][add-app-shield]][add-app]
 
 ## Access & Login
 
@@ -18,7 +18,7 @@ défaut. Cela signifie que tout utilisateur HA peut ouvrir l'interface
 utilisateur et se connecter avec ses informations d'identification HA.
 Chaque utilisateur HA aura son propre compte dans Sharry et ses propres partages.
 
-L'add-on est configuré pour que toutes les autres méthodes de connexion et
+L'app est configuré pour que toutes les autres méthodes de connexion et
 d'enregistrement de nouveaux utilisateurs par défaut soient désactivées.
 Si vous souhaitez autoriser les utilisateurs à avoir des comptes uniquement
 avec Sharry, vous pouvez activer l'enregistrement d'utilisateurs et d'autres
@@ -30,9 +30,9 @@ Pour plus d'information vous pouvez consulter [Sharry coniguration][sharry-docs-
 
 ## Database Setup
 
-Cet add-on [Sharry][sharry] contient une base de données MariaDB pour
+Cet app [Sharry][sharry] contient une base de données MariaDB pour
 stocker ses données. Vous n'aurez donc PAS BESOIN d'installer
-l'[addon MariaDB][addon-mariadb].
+l'[app MariaDB][app-mariadb].
 
 Si vous le préférez, vous pouvez utiliser une base de données distante en
 remplissant toutes les options `remote_db_*` ci-dessous. Vous devrez créer
@@ -52,7 +52,7 @@ sauvegarder le dossier local
 
 ## Configuration
 
-Example add-on configuration:
+Example app configuration:
 
 ```yaml
 DefaultStore: database
@@ -97,7 +97,7 @@ des problèmes avec votre instance. À UTILISER À VOS RISQUES ET PÉRILS!_
 Celles-ci sont sensibles à la casse et tous les éléments définis par une
 configuration spécifique seront prioritaires. Ceux qui ne peuvent pas être
 remplacés sont signalés par un commentaire
-dans la [configuration par défaut][default-config] que cet add-on utilise.
+dans la [configuration par défaut][default-config] que cet app utilise.
 
 #### Sub-option: `conf_overrides.property` (required)
 
@@ -158,7 +158,7 @@ Par défaut `Sharry`
 A définir si vous souhaiter activer la copie des données partagées
 d'une base de données mariadb/postgres vers un stockage locale
 ou inversement.
-La copie est effectuée au démarrage de l'add-on.
+La copie est effectuée au démarrage de l'app.
 
 ### Option: `copy_db_source` (optional)
 
@@ -174,7 +174,7 @@ Le nom de domaine à partir duquel les utilisateurs accèderont à Sharry.
 Sharry reçoit une URL de base qu'elle utilise pour générer des URL et
 configurer des cookies. Cela sera créé à partir de cette option,
 de l'option `use_ssl` et du port que vous avez indiqué pour `9090`.
-Si le port n'est pas répertorié, l'add-on suppose que les utilisateurs
+Si le port n'est pas répertorié, l'app suppose que les utilisateurs
 n'incluent pas de port dans l'URL lorsqu'ils accèdent à Sharry.
 
 ### Option: `use_ssl` (optional)
@@ -189,7 +189,7 @@ et y activent les certificats SSL._
 
 ### Option: `no_port_to_Base_URL` (optional)
 
-Enlève le port de l'add-on de la base_url.
+Enlève le port de l'app de la base_url.
 La valeur par défaut est `false`.
 
 **Note**: _Probablement necessaire si vous utilisez un proxy inverse
@@ -247,7 +247,7 @@ Identifiants creer par Mariadb afin de donner un acces à la base de données. [
 Nom d'utilisateur de la database. [Documentation][username]
 
 _Veuillez ne pas la changer `sharry` pour assurer la compatibilitée. Ajouter en d'autres
-si vous en avez l'utilité pour d'autres add-ons_
+si vous en avez l'utilité pour d'autres apps_
 
 #### Sub-option: `logins.password` (required)
 
@@ -288,7 +288,7 @@ Vous pouvez consulter le changelog [GitHub ici][releases].
 ## Support
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][hacf] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.
@@ -346,12 +346,12 @@ SOFTWARE.
 > > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > > SOFTWARE._
 
-[add-addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_sharry-dependency-less
-[add-addon-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
+[add-app]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_sharry-dependency-less
+[add-app-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fcasse-boubou%2Fhassio-addons
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [default-config]: https://github.com/casse-boubou/addon-sharry-dependency-less/blob/main/sharry/rootfs/etc/sharry/sharry.conf
-[addon-mariadb]: https://github.com/home-assistant/addons/tree/master/mariadb
+[app-mariadb]: https://github.com/home-assistant/addons/tree/master/mariadb
 [discord-ha]: https://discord.gg/c5DvZ4e
 [forum]: https://community.home-assistant.io
 [hacf]: https://forum.hacf.fr/

--- a/sharry/DOCS.md
+++ b/sharry/DOCS.md
@@ -305,7 +305,7 @@ la [page des contributeurs][contributors].
 
 MIT License
 
-Copyright (c) 2022-2025 [Frosh][Frosh]
+Copyright (c) 2022-2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -25,7 +25,7 @@ RUN set -eux \
     apk add --no-cache \
         mariadb-client=11.4.8-r0 \
         netcat-openbsd=1.229.1-r0 \
-        openjdk17-jre=17.0.17_p10-r0
+        openjdk17-jre=17.0.18_p8-r0
 
 # Add Maria db
 RUN apk add --no-cache \

--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -58,7 +58,7 @@ LABEL \
     maintainer="Frosh" \
     org.opencontainers.image.title="${BUILD_NAME}" \
     org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
-    org.opencontainers.image.vendor="Frosh Home Assistant Add-ons" \
+    org.opencontainers.image.vendor="Frosh Home Assistant App" \
     org.opencontainers.image.authors="Frosh" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.url="https://github.com/casse-boubou/hassio-addons" \

--- a/sharry/rootfs/etc/cont-init.d/30-config.sh
+++ b/sharry/rootfs/etc/cont-init.d/30-config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Add-on: Sharry
+# Home Assistant App: Sharry
 # This validates config, creates the database and sets up app files/folders
 # ==============================================================================
 declare host
@@ -17,7 +17,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
         bashio::log.fatal
         bashio::log.fatal "Your config attempts to override settings in the command"
         bashio::log.fatal "auth module. This is not allowed as it would break the ability"
-        bashio::log.fatal "of this addon to authenticate users with Home Assistant."
+        bashio::log.fatal "of this app to authenticate users with Home Assistant."
         bashio::log.fatal
         bashio::log.fatal "Remove any conf_overrides you have added with a property"
         bashio::log.fatal "matching this pattern and try again:"
@@ -28,7 +28,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
     elif [[ ${property} =~ ^sharry[.]restserver[.]backend[.]files ]]; then
         bashio::log.fatal
         bashio::log.fatal "Your config attempts to override settings in the files module."
-        bashio::log.fatal "This is not allowed as it could break the addon."
+        bashio::log.fatal "This is not allowed as it could break the app."
         bashio::log.fatal
         bashio::log.fatal "Remove any conf_overrides you have added with a property"
         bashio::log.fatal "matching this pattern and try again:"
@@ -41,7 +41,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
     elif [[ ${property} =~ ^sharry[.]restserver[.]base-url ]]; then
         bashio::log.fatal
         bashio::log.fatal "Your config attempts to override log level settings."
-        bashio::log.fatal "This is not allowed as it could break the addon."
+        bashio::log.fatal "This is not allowed as it could break the app."
         bashio::log.fatal
         bashio::log.fatal "Remove any conf_overrides you have added with a property"
         bashio::log.fatal "matching this pattern:"
@@ -55,7 +55,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
     elif [[ ${property} =~ ^sharry[.]restserver[.]logging[.]minimum-level ]]; then
         bashio::log.fatal
         bashio::log.fatal "Your config attempts to override log level settings."
-        bashio::log.fatal "This is not allowed as it could break the addon."
+        bashio::log.fatal "This is not allowed as it could break the app."
         bashio::log.fatal
         bashio::log.fatal "Remove any conf_overrides you have added with a property"
         bashio::log.fatal "matching this pattern:"
@@ -69,7 +69,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
     elif [[ ${property} =~ ^sharry[.]restserver[.]bind[.]address ]]; then
         bashio::log.fatal
         bashio::log.fatal "Your config attempts to override settings in the bind module."
-        bashio::log.fatal "If you use NGINX this is not allowed as it could break the addon."
+        bashio::log.fatal "If you use NGINX this is not allowed as it could break the app."
         bashio::log.fatal
         bashio::log.fatal "Remove any conf_overrides you have added with a property"
         bashio::log.fatal "matching this pattern and try again:"
@@ -79,7 +79,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
     elif [[ ${property} =~ ^sharry[.]restserver[.]bind[.]port ]]; then
         bashio::log.fatal
         bashio::log.fatal "Your config attempts to override settings in the bind module."
-        bashio::log.fatal "If you use NGINX this is not allowed as it could break the addon."
+        bashio::log.fatal "If you use NGINX this is not allowed as it could break the app."
         bashio::log.fatal "USE AT YOUR OWN RISK !!!!"
         bashio::log.fatal
         bashio::log.fatal "Please remove any conf_overrides you have added with a property"
@@ -93,7 +93,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
         bashio::log.fatal "WARNING"
         bashio::log.fatal "Your config attempts to override settings in the CHUNK-SIZE value."
         bashio::log.fatal "If you use NGINX do NOT exceed the value of 100M."
-        bashio::log.fatal "This is not allowed as it could break the addon."
+        bashio::log.fatal "This is not allowed as it could break the app."
         bashio::log.fatal
         bashio::log.fatal
     fi
@@ -106,12 +106,12 @@ done
 # Be sure that at least one database is activated
 if bashio::config.equals 'defaultStore' 'database'; then
     bashio::log.info "Sharry is using the Maria database storage"
-    bashio::log.notice "Please ensure that addon is included in your backups"
-    bashio::log.notice "Uninstalling the Maria DB addon will also remove Sharry's data"
+    bashio::log.notice "Please ensure that app is included in your backups"
+    bashio::log.notice "Uninstalling the Maria DB app will also remove Sharry's data"
 else
     bashio::log.info "Maria database storage is not actived..."
     bashio::log.notice "If you want use Maria database for data storage please"
-    bashio::log.notice "set DefaultStore to database in Add-on config"
+    bashio::log.notice "set DefaultStore to database in App config"
 fi
 if bashio::config.equals 'defaultStore' 'filesystem'; then
     if bashio::config.is_empty 'local_db'; then
@@ -122,10 +122,10 @@ if bashio::config.equals 'defaultStore' 'filesystem'; then
     fi
     bashio::log.info "Sharry is using the Local database storage"
     bashio::log.notice "Please ensure that directory is included in your backups"
-    bashio::log.notice "Uninstalling the Maria DB addon will also remove Sharry's data"
+    bashio::log.notice "Uninstalling the Maria DB app will also remove Sharry's data"
 else bashio::log.info "Local database storage is not actived..."
     bashio::log.notice "If you want use local database storage please"
-    bashio::log.notice "set DefaultStore to filesystem in Add-on config"
+    bashio::log.notice "set DefaultStore to filesystem in App config"
 fi
 
 

--- a/sharry/rootfs/etc/s6-overlay/s6-rc.d/sharry/run
+++ b/sharry/rootfs/etc/s6-overlay/s6-rc.d/sharry/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Add-on: Sharry
+# Home Assistant App: Sharry
 # Runs Sharry
 # ==============================================================================
 
@@ -22,7 +22,7 @@ declare -a conf_props=()
 
 
 # --- Wait for Mariadb is running ---
-# Basicaly, it save teh log of the addon in logfile.log and whait until
+# Basicaly, it save teh log of the app in logfile.log and whait until
 # see a log info of Mariadb i.e:"Sending service information to Home Assistant"
 touch /logfile.log
 method=GET
@@ -77,7 +77,7 @@ if ! bashio::config.is_empty 'remote_db_host'; then
 else
     if ! bashio::services.available 'mysql'; then
         bashio::log.fatal
-        bashio::log.fatal 'MariaDB addon not available and no alternate database supplied'
+        bashio::log.fatal 'MariaDB app not available and no alternate database supplied'
         bashio::log.fatal 'Ensure MariaDB is available or provide an alternate database'
         bashio::log.fatal
         bashio::exit.nok

--- a/sharry/rootfs/etc/sharry/sharry.conf
+++ b/sharry/rootfs/etc/sharry/sharry.conf
@@ -161,7 +161,7 @@ sharry.restserver {
 
       # Primary mechanism of auth is to validate credentials with Home
       # Assistant. User cannot disable or change the command login
-      # module in addon config. All others are disabled by default but
+      # module in app config. All others are disabled by default but
       # user can enable them with advanced options if they wish.
       #### CANNOT OVERRIDE
       command {

--- a/sharry/rootfs/usr/bin/lock-tables-for-backup
+++ b/sharry/rootfs/usr/bin/lock-tables-for-backup
@@ -5,6 +5,6 @@
 # Lock tables for backup
 # ==============================================================================
 
-# Redirect stdout to the add-on's log
+# Redirect stdout to the app's log
 exec &> /proc/1/fd/1
 exec s6-rc -v 2 -u change mariadb-lock

--- a/sharry/rootfs/usr/bin/unlock-tables-for-backup
+++ b/sharry/rootfs/usr/bin/unlock-tables-for-backup
@@ -5,6 +5,6 @@
 # Unlock tables for backup
 # ==============================================================================
 
-# Redirect stdout to the add-on's log
+# Redirect stdout to the app's log
 exec &> /proc/1/fd/1
 exec s6-rc -v 2 -d change mariadb-lock

--- a/sharry/translations/en.yaml
+++ b/sharry/translations/en.yaml
@@ -44,7 +44,7 @@ configuration:
     description: Change 'http' to 'https' in the base_url.
   no_port_to_Base_URL:
     name: Remove port from base_url
-    description: Remove the add-on port from the base_url (maybe necessary if you use a reverse proxy).
+    description: Remove the app port from the base_url (maybe necessary if you use a reverse proxy).
   default_language:
     name: Default language
     description: An ISO 3166-1 country code.

--- a/sharry/translations/fr.yaml
+++ b/sharry/translations/fr.yaml
@@ -44,7 +44,7 @@ configuration:
     description: Change 'http' en 'https' dans la base_url.
   no_port_to_Base_URL:
     name: Retire le port de la base_url
-    description: Retire le port de l'add-on de la base_url (probablement nécessaire si vous utilisez un proxy inverse)
+    description: Retire le port de l'app de la base_url (probablement nécessaire si vous utilisez un proxy inverse)
   default_language:
     name: Langue
     description: Un code pays ISO 3166-1 pour la langue de Sharry.


### PR DESCRIPTION
# Changes

In version 2026.2, HA decided to rename its “add-ons” to “Apps.”
This update renames items in accordance with the new nomenclature.

https://www.home-assistant.io/blog/2026/02/04/release-20262/#add-ons-are-now-called-apps
Or github discussion
https://github.com/home-assistant/architecture/discussions/1287